### PR TITLE
Add 'full' option to get all package details not just version number.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,17 +14,20 @@ module.exports = pkg => {
   if (!pkg || !pkg.name) {
     throw new Error('You must provide a package name');
   }
-  
+
   pkg.version = pkg.version || '*';
-  
+
   if (!semver.validRange(pkg.version)) {
     throw new Error('That is not a valid package version range');
-  } 
-  
-  pkg.registry = pkg.registry || 'http://registry.npmjs.com/'; 
-  
+  }
+
+  pkg.registry = pkg.registry || 'http://registry.npmjs.com/';
+
   return fetch(url.resolve(pkg.registry, pkg.name))
     .then(response => response.json())
-    .then(data => semver.maxSatisfying(Object.keys(data.versions || {}), pkg.version))
+    .then(data => {
+      let v = semver.maxSatisfying(Object.keys(data.versions || {}), pkg.version);
+      return (pkg.full) ? data.versions[v] : v;
+    })
     .catch(err => { throw new Error(err); });
 }


### PR DESCRIPTION
Hi sillero,
Would you be interested in this 'full' option? It returns the full json description rather than just the version. I'm using it because in addition to knowing what version number, I want to know tarball and shasum.

Example:

```
// For version ranges, we need to do a network request to resolve.
// Also, get the tarball_url and checksum
let v = yield resolve({
  name: m.urlsafe_fullname,
  version: m.version,
  registry: 'http://registry.npmjs.org',
  full: true
})
m.exact_version = v.version
m.tarball_sha = v.dist.shasum
m.tarball_url = v.dist.tarball
```

It's backwards compatible, because if you don't include `full: true` then it works just as before.
